### PR TITLE
Fixed Assertion Exception in CPlugins::LoadPlugins

### DIFF
--- a/server/plugins.cpp
+++ b/server/plugins.cpp
@@ -440,7 +440,11 @@ void CPlugins::LoadPlugins(std::string strPath)
 		{
 			logprintf(" Loading plugin: %s", strPlugin.c_str());
 
-			for (unsigned char i = 0; i < sizeof(g_szBlacklist); i++) {
+			/*
+			Assertion Exception is thrown here.
+			The sizeof(g_szBlacklist) is 16, must be 4.
+			*/
+			for (unsigned char i = 0; i < sizeof(g_szBlacklist)/sizeof(char*); i++) {
 				if (stricmp(strPlugin.c_str(), g_szBlacklist[i]) == 0) {
 					logprintf("  Blacklisted - Loading this plugin will cause a server crash.");
 					continue;


### PR DESCRIPTION
The for loop used for looping trough the blacklisted plugin names used the sizeof g_szBlacklist(Wich is a char* array of size 4) returning the size of 16 bytes. Fixed by deleting the size of g_szBlacklist with the size of char*.