### PR TITLE
rename class function names and add CAudio class stubs

### DIFF
--- a/saco/audiostream.cpp
+++ b/saco/audiostream.cpp
@@ -1,42 +1,42 @@
 
 #include "audiostream.h"
 
-void CAudioStream::sub_10066480()
+void CAudioStream::Reset()
 {
 	// TODO: CAudioStream::sub_10066480 10066480
 }
 
-void CAudioStream::sub_10066560()
+void CAudioStream::Stop()
 {
 	// TODO: CAudioStream::sub_10066560 10066560
 }
 
-void CAudioStream::sub_100665C0()
+void CAudioStream::ConstructInfo()
 {
 	// TODO: CAudioStream::sub_100665C0 100665C0
 }
 
-void CAudioStream::sub_100666F0()
+void CAudioStream::SyncProc()
 {
 	// TODO: CAudioStream::sub_100666F0 100666F0
 }
 
-void CAudioStream::sub_10066700()
+void CAudioStream::Process()
 {
 	// TODO: CAudioStream::sub_10066700 10066700
 }
 
-void CAudioStream::sub_10066960()
+void CAudioStream::Play()
 {
 	// TODO: CAudioStream::sub_10066960 10066960
 }
 
-void CAudioStream::sub_10066A80()
+void CAudioStream::ControlGameRadio()
 {
 	// TODO: CAudioStream::sub_10066A80 10066A80
 }
 
-void CAudioStream::sub_10066AB0()
+void CAudioStream::DrawInfo()
 {
 	// TODO: CAudioStream::sub_10066AB0 10066AB0
 }

--- a/saco/audiostream.h
+++ b/saco/audiostream.h
@@ -12,12 +12,12 @@ public:
 		field_0 = 0;
 	}
 
-	void sub_10066480();
-	void sub_10066560();
-	void sub_100665C0();
-	void sub_100666F0();
-	void sub_10066700();
-	void sub_10066960();
-	void sub_10066A80();
-	void sub_10066AB0();
+	void Reset();
+	void Stop();
+	void ConstructInfo();
+	void SyncProc();
+	void Process();
+	void Play();
+	void ControlGameRadio();
+	void DrawInfo();
 };

--- a/saco/game/audio.cpp
+++ b/saco/game/audio.cpp
@@ -1,0 +1,36 @@
+#include "audio.h"
+
+void CAudio::GetRadioStation() 
+{
+    // TODO: CAudio::sub_100A2210 100A2210
+}
+
+void CAudio::StartRadio()
+{
+    // TODO: CAudio::sub_100A2240 100A2240
+}
+
+void CAudio::GetRadioVolume()
+{
+    // TODO: CAudio::sub_100A2280 100A2280
+}
+
+void CAudio::StopOutdoorAmbienceTrack()
+{
+    // TODO: CAudio::sub_100A2290 100A2290
+}
+
+void CAudio::SetOutdoorAmbienceTrack()
+{
+    // TODO: CAudio::sub_100A22A0 100A22A0
+}
+
+void CAudio::Play() 
+{
+    // TODO: CAudio::sub_100A22C0 100A22C0
+}
+
+void CAudio::IsOutdoorAmbienceTrackDisabled()
+{
+    // TODO: CAudio::sub_100A23A0 100A23A0
+}

--- a/saco/game/audio.h
+++ b/saco/game/audio.h
@@ -12,4 +12,12 @@ public:
 		field_0 = 0;
 		field_4 = 0;
 	}
+
+	void GetRadioStation();
+	void StartRadio();
+	void GetRadioVolume();
+	void StopOutdoorAmbienceTrack();
+	void SetOutdoorAmbienceTrack();
+	void Play();
+	void IsOutdoorAmbienceTrackDisabled();
 };


### PR DESCRIPTION
The CAudioStream class function names have been renamed and the functions I found in the CAudio function have been added,

All memory addresses of the functions that have been found so far have been added to a TODO with their respective memory addresses.